### PR TITLE
Change how to determine host IP address

### DIFF
--- a/plugins/meta/podman-machine/main.go
+++ b/plugins/meta/podman-machine/main.go
@@ -36,6 +36,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to parse config")
 	}
+
 	hostAddr, err := getPrimaryIP()
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously we determined the host IP address by performing a UDP
connection and examining the default route used.  This does not work in
rootless because the cni plugin runs in a separate network namespace.
Now we look for the host IP address as an environment variable which is
reliable for rootful and rootless.

Signed-off-by: Brent Baude <bbaude@redhat.com>