### PR TITLE
Get host IP from env

### DIFF
--- a/plugins/meta/podman-machine/main.go
+++ b/plugins/meta/podman-machine/main.go
@@ -36,14 +36,12 @@ func cmdAdd(args *skel.CmdArgs) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to parse config")
 	}
+
 	hostAddr, err := getPrimaryIP()
 	if err != nil {
 		return err
 	}
-	// No portmappings, do nothing
-	if len(portMaps.RuntimeConfig.PortMaps) < 1 {
-		return nil
-	}
+
 	// Iterate and send requests to the server
 	for _, pm := range portMaps.RuntimeConfig.PortMaps {
 		hostPort := strconv.Itoa(pm.HostPort)

--- a/plugins/meta/podman-machine/restful.go
+++ b/plugins/meta/podman-machine/restful.go
@@ -9,8 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-
-	"github.com/sirupsen/logrus"
+	"os"
 )
 
 type Expose struct {
@@ -22,19 +21,18 @@ type Unexpose struct {
 	Local string `json:"local"`
 }
 
+// getPrimaryIP extracts the host's IP address from an environment
+// variable. It is an error if that IP is blank
 func getPrimaryIP() (net.IP, error) {
-	// no connection is actually made here
-	conn, err := net.Dial("udp", "8.8.8.8:80")
-	if err != nil {
-		return nil, err
+	hostIP := os.Getenv("PODMAN_MACHINE_HOST")
+	if len(hostIP) < 1 {
+		return nil, errors.New("invalid PODMAN_MACHINE_HOST environment variable")
 	}
-	defer func() {
-		if err := conn.Close(); err != nil {
-			logrus.Error(err)
-		}
-	}()
-	addr := conn.LocalAddr().(*net.UDPAddr)
-	return addr.IP, nil
+	addr := net.ParseIP(hostIP)
+	if addr == nil {
+		return nil, errors.New("unable to parse PODMAN_HOST_MACHINE IP address")
+	}
+	return addr, nil
 }
 
 func postRequest(ctx context.Context, url *url.URL, body interface{}) error {


### PR DESCRIPTION
When running cni plugins rootless, they are run inside the cni network
namespace.  This means the IP address will differ from the hosts and
will not route correctly.

Signed-off-by: Brent Baude <bbaude@redhat.com>